### PR TITLE
Set default endpoint to AWS S3 endpoint

### DIFF
--- a/s3-benchmark.go
+++ b/s3-benchmark.go
@@ -375,7 +375,7 @@ func main() {
 	myflag := flag.NewFlagSet("myflag", flag.ExitOnError)
 	myflag.StringVar(&accessKey, "a", "", "Access key")
 	myflag.StringVar(&secretKey, "s", "", "Secret key")
-	myflag.StringVar(&urlHost, "u", "http://s3.wasabisys.com", "URL for host with method prefix")
+	myflag.StringVar(&urlHost, "u", "https://s3.amazonaws.com", "URL for host with method prefix")
 	myflag.StringVar(&bucket, "b", "wasabi-benchmark-bucket", "Bucket for testing")
 	myflag.IntVar(&durationSecs, "d", 60, "Duration of each test in seconds")
 	myflag.IntVar(&threads, "t", 1, "Number of threads to run")


### PR DESCRIPTION
I think this is a more sensible default (I know it was originally a tool written by wasabi).